### PR TITLE
Remove unwraps/propagate errors

### DIFF
--- a/bracket-terminal/examples/astar_mouse.rs
+++ b/bracket-terminal/examples/astar_mouse.rs
@@ -177,8 +177,8 @@ impl GameState for State {
         );
 
         // Submit the rendering
-        draw_batch.submit(0);
-        render_draw_buffer(ctx);
+        draw_batch.submit(0).unwrap();
+        render_draw_buffer(ctx).unwrap();
     }
 }
 
@@ -239,7 +239,8 @@ impl Algorithm2D for State {
 fn main() {
     let context = BTermBuilder::simple80x50()
         .with_title("Bracket Terminal Example - A* Mouse")
-        .build();
+        .build()
+        .unwrap();
     let gs = State::new();
-    main_loop(context, gs);
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/examples/dwarfmap.rs
+++ b/bracket-terminal/examples/dwarfmap.rs
@@ -324,7 +324,8 @@ impl Algorithm3D for State {
 fn main() {
     let context = BTermBuilder::simple80x50()
         .with_title("Bracket Terminal Example - Dwarf Fortress Map Style")
-        .build();
+        .build()
+        .unwrap();
     let gs = State::new();
-    main_loop(context, gs);
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/examples/hello_minimal.rs
+++ b/bracket-terminal/examples/hello_minimal.rs
@@ -33,12 +33,13 @@ fn main() {
     // with the baked-in 8x8 terminal font.
     let context = BTermBuilder::simple80x50()
         .with_title("Hello Minimal Bracket World")
-        .build();
+        .build()
+        .unwrap();
 
     // Now we create an empty state object.
     let gs: State = State {};
 
     // Call into BTerm to run the main loop. This handles rendering, and calls back into State's tick
     // function every cycle. The box is needed to work around lifetime handling.
-    main_loop(context, gs);
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/examples/hello_terminal.rs
+++ b/bracket-terminal/examples/hello_terminal.rs
@@ -88,7 +88,8 @@ fn main() {
     let context = BTermBuilder::simple80x50()
         .with_title("Hello Bracket World")
         .with_fps_cap(30.0)
-        .build();
+        .build()
+        .unwrap();
 
     // Now we create an empty state object.
     let gs: State = State {
@@ -98,5 +99,5 @@ fn main() {
 
     // Call into BTerm to run the main loop. This handles rendering, and calls back into State's tick
     // function every cycle. The box is needed to work around lifetime handling.
-    main_loop(context, gs);
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/examples/keyboard.rs
+++ b/bracket-terminal/examples/keyboard.rs
@@ -32,11 +32,12 @@ impl GameState for State {
 fn main() {
     let context = BTermBuilder::simple80x50()
         .with_title("RLTK Example 16 - Keyboard Input Visualizer")
-        .build();
+        .build()
+        .unwrap();
 
     let gs: State = State {
         display_lines: vec!["Press keys and modifiers to see code combinations.".to_string()],
     };
 
-    main_loop(context, gs);
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/examples/postprocess.rs
+++ b/bracket-terminal/examples/postprocess.rs
@@ -53,12 +53,13 @@ fn main() {
 
     let mut context = BTermBuilder::simple80x50()
         .with_title("Bracket Terminal Example - Post-Processing Effects")
-        .build();
+        .build()
+        .unwrap();
 
     context.with_post_scanlines(true);
     let gs: State = State {
         nyan: xp,
         burn: true,
     };
-    main_loop(context, gs);
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/examples/rex.rs
+++ b/bracket-terminal/examples/rex.rs
@@ -36,7 +36,8 @@ fn main() {
 
     let context = BTermBuilder::simple80x50()
         .with_title("Bracket Terminal Example - REX Paint, Hello Nyan Cat")
-        .build();
+        .build()
+        .unwrap();
     let gs: State = State { nyan: xp };
-    main_loop(context, gs);
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/examples/sparse.rs
+++ b/bracket-terminal/examples/sparse.rs
@@ -57,9 +57,9 @@ impl GameState for State {
             &format!("Frame Time: {} ms", ctx.frame_time_ms),
             ColorPair::new(RGB::named(CYAN), RGB::named(BLACK)),
         );
-        draw_batch.submit(0);
+        draw_batch.submit(0).unwrap();
 
-        render_draw_buffer(ctx);
+        render_draw_buffer(ctx).unwrap();
     }
 }
 
@@ -68,12 +68,13 @@ fn main() {
         .with_font("vga8x16.png", 8u32, 16u32)
         .with_sparse_console(80u32, 25u32, "vga8x16.png")
         .with_title("Bracket Terminal - Sparse Consoles")
-        .build();
+        .build()
+        .unwrap();
 
     let gs = State {
         y: 1,
         going_down: true,
     };
 
-    main_loop(context, gs);
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/examples/textblock.rs
+++ b/bracket-terminal/examples/textblock.rs
@@ -39,6 +39,7 @@ fn main() {
 
     let context = BTermBuilder::simple80x50()
         .with_title("Bracket Terminal Example - Text Blocks")
-        .build();
-    main_loop(context, gs);
+        .build()
+        .unwrap();
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/examples/textsprites.rs
+++ b/bracket-terminal/examples/textsprites.rs
@@ -63,9 +63,9 @@ impl GameState for State {
             ColorPair::new(RGB::named(CYAN), RGB::named(BLACK)),
         );
         self.sprite.add_to_batch(&mut draw_batch, Point::new(40, 3));
-        draw_batch.submit(0);
+        draw_batch.submit(0).unwrap();
 
-        render_draw_buffer(ctx);
+        render_draw_buffer(ctx).unwrap();
     }
 }
 
@@ -78,7 +78,8 @@ fn main() {
         .with_font("vga8x16.png", 8u32, 16u32)
         .with_sparse_console(80u32, 25u32, "vga8x16.png")
         .with_title("Bracket Terminal Example - Text Sprites")
-        .build();
+        .build()
+        .unwrap();
 
     let gs = State {
         y: 1,
@@ -103,5 +104,5 @@ fn main() {
         nyancat: MultiTileSprite::from_xp(&XpFile::from_resource("../resources/nyan.xp").unwrap()),
     };
 
-    main_loop(context, gs);
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/examples/tiles.rs
+++ b/bracket-terminal/examples/tiles.rs
@@ -167,9 +167,9 @@ impl GameState for State {
             2,
         );
 
-        draw_batch.submit(0);
+        draw_batch.submit(0).unwrap();
 
-        render_draw_buffer(ctx);
+        render_draw_buffer(ctx).unwrap();
     }
 }
 
@@ -205,8 +205,9 @@ fn main() {
         // We also want a sparse console atop it to handle moving the character
         .with_sparse_console(WIDTH as u32, HEIGHT as u32, "example_tiles.png")
         // And we call the builder function
-        .build();
+        .build()
+        .unwrap();
 
     let gs = State::new();
-    main_loop(context, gs);
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/examples/walking.rs
+++ b/bracket-terminal/examples/walking.rs
@@ -167,7 +167,8 @@ impl GameState for State {
 fn main() {
     let context = BTermBuilder::simple80x50()
         .with_title("Bracket Terminal Example - Walking")
-        .build();
+        .build()
+        .unwrap();
     let gs = State::new();
-    main_loop(context, gs);
+    main_loop(context, gs).unwrap();
 }

--- a/bracket-terminal/src/bterm.rs
+++ b/bracket-terminal/src/bterm.rs
@@ -60,7 +60,7 @@ impl BTerm {
         } else {
             return Err("Couldn't convert to u32".into());
         };
-        Ok(init_raw(w, h, window_title, platform_hints))
+        Ok(init_raw(w, h, window_title, platform_hints)?)
     }
 
     /// Quick initialization for when you just want an 8x8 font terminal

--- a/bracket-terminal/src/bterm.rs
+++ b/bracket-terminal/src/bterm.rs
@@ -82,7 +82,7 @@ impl BTerm {
         let font_path = format!("{}/terminal8x8.png", &path_to_shaders.to_string());
         let mut context = BTerm::init_raw(w * 8, h * 8, window_title, InitHints::new()).unwrap();
         let font = context.register_font(Font::load(&font_path.to_string(), (8, 8)));
-        context.register_console(SimpleConsole::init(w, h, &context.backend), font);
+        context.register_console(SimpleConsole::init(w, h, &context.backend), font.unwrap());
         context
     }
 
@@ -105,16 +105,16 @@ impl BTerm {
         let font_path = format!("{}/vga8x16.png", &path_to_shaders.to_string());
         let mut context = BTerm::init_raw(w * 8, h * 16, window_title, InitHints::new()).unwrap();
         let font = context.register_font(Font::load(&font_path.to_string(), (8, 16)));
-        context.register_console(SimpleConsole::init(w, h, &context.backend), font);
+        context.register_console(SimpleConsole::init(w, h, &context.backend), font.unwrap());
         context
     }
 
     /// Registers a font, and returns its handle number. Also loads it into OpenGL.
-    pub fn register_font(&mut self, mut font: Font) -> usize {
-        font.setup_gl_texture(&self.backend);
+    pub fn register_font(&mut self, mut font: Font) -> Result<usize> {
+        font.setup_gl_texture(&self.backend)?;
         font.bind_texture(&self.backend);
         self.fonts.push(font);
-        self.fonts.len() - 1
+        Ok(self.fonts.len() - 1)
     }
 
     /// Registers a new console terminal for output, and returns its handle number.

--- a/bracket-terminal/src/bterm.rs
+++ b/bracket-terminal/src/bterm.rs
@@ -1,7 +1,10 @@
-use crate::prelude::{
-    font::Font, init_raw, Console, InitHints, BTermPlatform,
-    Shader, SimpleConsole, VirtualKeyCode, XpLayer, XpFile,
-    GameState
+use crate::{
+    Result,
+    prelude::{
+        font::Font, init_raw, Console, InitHints, BTermPlatform,
+        Shader, SimpleConsole, VirtualKeyCode, XpLayer, XpFile,
+        GameState
+    },
 };
 use std::any::Any;
 use std::convert::TryInto;
@@ -46,13 +49,18 @@ impl BTerm {
         height_pixels: T,
         window_title: S,
         platform_hints: InitHints,
-    ) -> BTerm
+    ) -> Result<BTerm>
     where
         T: TryInto<u32>,
     {
-        let w: u32 = width_pixels.try_into().ok().unwrap();
-        let h: u32 = height_pixels.try_into().ok().unwrap();
-        init_raw(w, h, window_title, platform_hints)
+        let w = width_pixels.try_into();
+        let h = height_pixels.try_into();
+        let (w, h) = if let (Ok(w), Ok(h)) = (w, h) {
+            (w, h)
+        } else {
+            return Err("Couldn't convert to u32".into());
+        };
+        Ok(init_raw(w, h, window_title, platform_hints))
     }
 
     /// Quick initialization for when you just want an 8x8 font terminal
@@ -72,7 +80,7 @@ impl BTerm {
         let w: u32 = width_chars.try_into().ok().unwrap();
         let h: u32 = height_chars.try_into().ok().unwrap();
         let font_path = format!("{}/terminal8x8.png", &path_to_shaders.to_string());
-        let mut context = BTerm::init_raw(w * 8, h * 8, window_title, InitHints::new());
+        let mut context = BTerm::init_raw(w * 8, h * 8, window_title, InitHints::new()).unwrap();
         let font = context.register_font(Font::load(&font_path.to_string(), (8, 8)));
         context.register_console(SimpleConsole::init(w, h, &context.backend), font);
         context
@@ -95,7 +103,7 @@ impl BTerm {
         let w: u32 = width_chars.try_into().ok().unwrap();
         let h: u32 = height_chars.try_into().ok().unwrap();
         let font_path = format!("{}/vga8x16.png", &path_to_shaders.to_string());
-        let mut context = BTerm::init_raw(w * 8, h * 16, window_title, InitHints::new());
+        let mut context = BTerm::init_raw(w * 8, h * 16, window_title, InitHints::new()).unwrap();
         let font = context.register_font(Font::load(&font_path.to_string(), (8, 16)));
         context.register_console(SimpleConsole::init(w, h, &context.backend), font);
         context

--- a/bracket-terminal/src/bterm.rs
+++ b/bracket-terminal/src/bterm.rs
@@ -373,8 +373,9 @@ impl Console for BTerm {
 }
 
 /// Runs the BTerm application, calling into the provided gamestate handler every tick.
-pub fn main_loop<GS: GameState>(bterm: BTerm, gamestate: GS) {
-    super::hal::main_loop(bterm, gamestate);
+pub fn main_loop<GS: GameState>(bterm: BTerm, gamestate: GS) -> Result<()> {
+    super::hal::main_loop(bterm, gamestate)?;
+    Ok(())
 }
 
 /// For A-Z menus, translates the keys A through Z into 0..25

--- a/bracket-terminal/src/hal/amethyst_be/dummy.rs
+++ b/bracket-terminal/src/hal/amethyst_be/dummy.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::hal::BTermPlatform;
 use super::font::Font;
 use super::shader::Shader;
@@ -29,7 +30,8 @@ impl SimpleConsoleBackend {
         _platform: &BTermPlatform,
         _width: u32,
         _height: u32,
-    ) {
+    ) -> Result<()> {
+        Ok(())
     }
 }
 
@@ -59,6 +61,7 @@ impl SparseConsoleBackend {
         _shader: &Shader,
         _platform: &BTermPlatform,
         _tiles: &[crate::sparse_console::SparseTile],
-    ) {
+    ) -> Result<()> {
+        Ok(())
     }
 }

--- a/bracket-terminal/src/hal/amethyst_be/font.rs
+++ b/bracket-terminal/src/hal/amethyst_be/font.rs
@@ -23,7 +23,9 @@ impl Font {
         }
     }
 
-    pub fn setup_gl_texture(&mut self, _gl: &crate::hal::BTermPlatform) {}
+    pub fn setup_gl_texture(&mut self, _gl: &crate::hal::BTermPlatform) -> Result<()> {
+        Ok(())
+    }
 
     pub fn bind_texture(&self, _gl: &crate::hal::BTermPlatform) {}
 }

--- a/bracket-terminal/src/hal/amethyst_be/font.rs
+++ b/bracket-terminal/src/hal/amethyst_be/font.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::prelude::BTerm;
 use amethyst::{
     assets::Handle,
@@ -27,7 +28,7 @@ impl Font {
     pub fn bind_texture(&self, _gl: &crate::hal::BTermPlatform) {}
 }
 
-pub fn initialize_fonts(bterm: &mut BTerm, world: &mut World) {
+pub fn initialize_fonts(bterm: &mut BTerm, world: &mut World) -> Result<()> {
     use crate::embedding;
     use amethyst::renderer::rendy::texture::TextureBuilder;
     use amethyst::renderer::types::TextureData;
@@ -43,8 +44,7 @@ pub fn initialize_fonts(bterm: &mut BTerm, world: &mut World) {
 
     for font in bterm.fonts.iter_mut() {
         let resource = embedding::EMBED
-            .lock()
-            .unwrap()
+            .lock()?
             .get_resource(font.filename.to_string());
 
         let handle;
@@ -93,7 +93,7 @@ pub fn initialize_fonts(bterm: &mut BTerm, world: &mut World) {
         } else {
             let filename = app_root.join(font.filename.clone());
             handle = loader.load(
-                filename.to_str().unwrap(),
+                filename.to_str().ok_or("Couldn't convert filename to string")?,
                 ImageFormat::default(),
                 (),
                 &texture_storage,
@@ -134,4 +134,5 @@ pub fn initialize_fonts(bterm: &mut BTerm, world: &mut World) {
         );
         font.ss = Some(ss_handle);
     }
+    Ok(())
 }

--- a/bracket-terminal/src/hal/amethyst_be/init.rs
+++ b/bracket-terminal/src/hal/amethyst_be/init.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::hal::BTermPlatform;
 use crate::prelude::InitHints;
 use crate::prelude::BTerm;
@@ -12,8 +13,8 @@ pub fn init_raw<S: ToString>(
     height_pixels: u32,
     window_title: S,
     platform_hints: InitHints,
-) -> BTerm {
-    BTerm {
+) -> Result<BTerm> {
+    let bterm = BTerm {
         backend: BTermPlatform {
             platform: PlatformGL {
                 window_title: window_title.to_string(),
@@ -38,5 +39,6 @@ pub fn init_raw<S: ToString>(
         quitting: false,
         post_scanlines: false,
         post_screenburn: false,
-    }
+    };
+    Ok(bterm)
 }

--- a/bracket-terminal/src/hal/amethyst_be/mainloop.rs
+++ b/bracket-terminal/src/hal/amethyst_be/mainloop.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::prelude::{GameState, BTerm};
 
 use amethyst::{
@@ -29,7 +30,7 @@ impl SimpleState for BTermGemBridge {
         let world = data.world;
         world.register::<SimpleConsoleLink>();
         self.make_camera(world);
-        super::font::initialize_fonts(&mut self.bterm, world);
+        super::font::initialize_fonts(&mut self.bterm, world).unwrap();
         self.initialize_console_objects(world);
     }
 
@@ -248,14 +249,14 @@ impl BTermGemBridge {
     }
 }
 
-pub fn main_loop<GS: GameState>(bterm: BTerm, gamestate: GS) {
+pub fn main_loop<GS: GameState>(bterm: BTerm, gamestate: GS) -> Result<()> {
     amethyst::start_logger(Default::default());
 
     let mut cfg = amethyst::window::DisplayConfig::default();
     cfg.dimensions = Some((bterm.width_pixels, bterm.height_pixels));
     cfg.title = bterm.backend.platform.window_title.clone();
 
-    let app_root = application_root_dir().unwrap();
+    let app_root = application_root_dir()?;
 
     let input_bundle = InputBundle::<StringBindings>::new().with_bindings(Bindings::new());
 
@@ -286,6 +287,7 @@ pub fn main_loop<GS: GameState>(bterm: BTerm, gamestate: GS) {
     )
     .expect("Failed to make game data");
     game.run();
+    Ok(())
 }
 
 #[derive(Clone, Debug)]

--- a/bracket-terminal/src/hal/crossterm_be/main_loop.rs
+++ b/bracket-terminal/src/hal/crossterm_be/main_loop.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::prelude::{GameState, BTerm, VirtualKeyCode};
 use crossterm::event::{poll, read, Event};
 use crossterm::execute;
@@ -6,7 +7,7 @@ use std::io::{stdout, Write};
 use std::time::Duration;
 use std::time::Instant;
 
-pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) {
+pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) -> Result<()> {
     let now = Instant::now();
     let mut prev_seconds = now.elapsed().as_secs();
     let mut prev_ms = now.elapsed().as_millis();
@@ -38,7 +39,7 @@ pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) {
         bterm.alt = false;
 
         // Input handler goes here
-        while poll(Duration::from_secs(0)).unwrap() {
+        while poll(Duration::from_secs(0))? {
             match read().expect("Uh oh") {
                 Event::Mouse(event) => {
                     //println!("{:?}", event);
@@ -199,4 +200,5 @@ pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) {
     )
     .expect("Unable to recolor");
     execute!(stdout(), crossterm::cursor::Show).expect("Command fail");
+    Ok(())
 }

--- a/bracket-terminal/src/hal/crossterm_be/mod.rs
+++ b/bracket-terminal/src/hal/crossterm_be/mod.rs
@@ -43,6 +43,7 @@ pub mod shader {
 }
 
 pub mod font {
+    use crate::Result;
     pub struct Font {
         pub tile_size: (u32, u32),
     }
@@ -52,7 +53,9 @@ pub mod font {
             Font { tile_size: (0, 0) }
         }
 
-        pub fn setup_gl_texture(&mut self, _gl: &crate::hal::BTermPlatform) {}
+        pub fn setup_gl_texture(&mut self, _gl: &crate::hal::BTermPlatform) -> Result<()> {
+            Ok(())
+        }
 
         pub fn bind_texture(&self, _gl: &crate::hal::BTermPlatform) {}
     }

--- a/bracket-terminal/src/hal/crossterm_be/mod.rs
+++ b/bracket-terminal/src/hal/crossterm_be/mod.rs
@@ -1,4 +1,5 @@
 // Dummy platform to let it compile and do nothing. Only useful if you don't want a graphical backend.
+use crate::Result;
 use crossterm::{
     execute,
     terminal::{size, SetSize},
@@ -62,7 +63,7 @@ pub fn init_raw<S: ToString>(
     height_pixels: u32,
     _window_title: S,
     platform_hints: InitHints,
-) -> BTerm {
+) -> Result<BTerm> {
     let old_size = size().expect("Unable to get console size");
     println!("Old size: {:?}", old_size);
     println!("Resizing to {}x{}", 80, 50);
@@ -75,7 +76,7 @@ pub fn init_raw<S: ToString>(
     execute!(stdout(), crossterm::cursor::Hide).expect("Command fail");
     execute!(stdout(), crossterm::event::EnableMouseCapture).expect("Command fail");
 
-    BTerm {
+    let bterm = BTerm {
         backend: super::BTermPlatform {
             platform: PlatformGL {
                 old_width: old_size.0,
@@ -101,7 +102,8 @@ pub fn init_raw<S: ToString>(
         quitting: false,
         post_scanlines: false,
         post_screenburn: false,
-    }
+    };
+    Ok(bterm)
 }
 
 pub struct SparseConsoleBackend {}
@@ -130,7 +132,8 @@ impl SparseConsoleBackend {
         _shader: &shader::Shader,
         _platform: &super::BTermPlatform,
         _tiles: &[crate::sparse_console::SparseTile],
-    ) {
+    ) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/bracket-terminal/src/hal/crossterm_be/simple_console_backing.rs
+++ b/bracket-terminal/src/hal/crossterm_be/simple_console_backing.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::prelude::{BTermPlatform, to_char, Tile};
 use super::font;
 use super::shader;
@@ -39,7 +40,7 @@ impl SimpleConsoleBackend {
         _platform: &BTermPlatform,
         width: u32,
         height: u32,
-    ) {
+    ) -> Result<()> {
         let mut idx = 0;
         let mut last_bg = RGB::new();
         let mut last_fg = RGB::new();
@@ -76,5 +77,6 @@ impl SimpleConsoleBackend {
                 idx += 1;
             }
         }
+        Ok(())
     }
 }

--- a/bracket-terminal/src/hal/curses/main_loop.rs
+++ b/bracket-terminal/src/hal/curses/main_loop.rs
@@ -1,9 +1,10 @@
+use crate::Result;
 use crate::prelude::{Console, GameState, BTerm};
 use crate::hal::VirtualKeyCode;
 use pancurses::{endwin, initscr, noecho, Window};
 use std::time::Instant;
 
-pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) {
+pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) -> Result<()> {
     let now = Instant::now();
     let mut prev_seconds = now.elapsed().as_secs();
     let mut prev_ms = now.elapsed().as_millis();
@@ -123,4 +124,5 @@ pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) {
     }
 
     endwin();
+    Ok(())
 }

--- a/bracket-terminal/src/hal/curses/mod.rs
+++ b/bracket-terminal/src/hal/curses/mod.rs
@@ -1,4 +1,5 @@
 // Dummy platform to let it compile and do nothing. Only useful if you don't want a graphical backend.
+use crate::Result;
 use crate::prelude::{GameState, BTerm};
 use bracket_color::prelude::*;
 
@@ -84,7 +85,7 @@ pub fn init_raw<S: ToString>(
     height_pixels: u32,
     _window_title: S,
     platform_hints: InitHints,
-) -> BTerm {
+) -> Result<BTerm> {
     let window = initscr();
     resize_term(height_pixels as i32 / 8, width_pixels as i32 / 8);
     noecho();
@@ -111,7 +112,7 @@ pub fn init_raw<S: ToString>(
         }
     }
 
-    BTerm {
+    let bterm = BTerm {
         backend: super::BTermPlatform {
             platform: PlatformGL {
                 window,
@@ -137,7 +138,8 @@ pub fn init_raw<S: ToString>(
         quitting: false,
         post_scanlines: false,
         post_screenburn: false,
-    }
+    };
+    Ok(bterm)
 }
 
 fn find_nearest_color(color: RGB, map: &[CursesColor]) -> i16 {

--- a/bracket-terminal/src/hal/curses/mod.rs
+++ b/bracket-terminal/src/hal/curses/mod.rs
@@ -43,6 +43,7 @@ pub mod shader {
 }
 
 pub mod font {
+    use crate::Result;
     pub struct Font {
         pub tile_size: (u32, u32),
     }
@@ -52,7 +53,9 @@ pub mod font {
             Font { tile_size: (1, 1) }
         }
 
-        pub fn setup_gl_texture(&mut self, _gl: &crate::hal::BTermPlatform) {}
+        pub fn setup_gl_texture(&mut self, _gl: &crate::hal::BTermPlatform) -> Result<()> {
+            Ok(())
+        }
 
         pub fn bind_texture(&self, _gl: &crate::hal::BTermPlatform) {}
     }

--- a/bracket-terminal/src/hal/curses/simple_console_backing.rs
+++ b/bracket-terminal/src/hal/curses/simple_console_backing.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::prelude::{BTermPlatform, to_char, Tile};
 use super::find_nearest_color;
 use super::font;
@@ -37,7 +38,7 @@ impl SimpleConsoleBackend {
         platform: &BTermPlatform,
         width: u32,
         height: u32,
-    ) {
+    ) -> Result<()> {
         let window = &platform.platform.window;
         let mut idx = 0;
         for y in 0..height {
@@ -46,7 +47,7 @@ impl SimpleConsoleBackend {
                 let cp_fg = find_nearest_color(t.fg, &platform.platform.color_map);
                 let cp_bg = find_nearest_color(t.bg, &platform.platform.color_map);
                 let pair = (cp_bg * 16) + cp_fg;
-                window.attrset(pancurses::COLOR_PAIR(pair.try_into().unwrap()));
+                window.attrset(pancurses::COLOR_PAIR(pair.try_into()?));
                 window.mvaddch(
                     height as i32 - (y as i32 + 1),
                     x as i32,
@@ -55,5 +56,6 @@ impl SimpleConsoleBackend {
                 idx += 1;
             }
         }
+        Ok(())
     }
 }

--- a/bracket-terminal/src/hal/curses/sparse_console_backing.rs
+++ b/bracket-terminal/src/hal/curses/sparse_console_backing.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::prelude::{BTermPlatform, to_char};
 use super::find_nearest_color;
 use super::font;
@@ -38,7 +39,7 @@ impl SparseConsoleBackend {
         _shader: &shader::Shader,
         platform: &BTermPlatform,
         tiles: &[crate::sparse_console::SparseTile],
-    ) {
+    ) -> Result<()> {
         let window = &platform.platform.window;
         for t in tiles.iter() {
             let x = t.idx as u32 % self.width;
@@ -54,5 +55,6 @@ impl SparseConsoleBackend {
                 to_char(t.glyph),
             );
         }
+        Ok(())
     }
 }

--- a/bracket-terminal/src/hal/curses/sparse_console_backing.rs
+++ b/bracket-terminal/src/hal/curses/sparse_console_backing.rs
@@ -48,7 +48,7 @@ impl SparseConsoleBackend {
             let cp_fg = find_nearest_color(t.fg, &platform.platform.color_map);
             let cp_bg = find_nearest_color(t.bg, &platform.platform.color_map);
             let pair = (cp_bg * 16) + cp_fg;
-            window.attrset(pancurses::COLOR_PAIR(pair.try_into().unwrap()));
+            window.attrset(pancurses::COLOR_PAIR(pair.try_into()?));
             window.mvaddch(
                 self.height as i32 - (y as i32 + 1),
                 x as i32,

--- a/bracket-terminal/src/hal/framebuffer.rs
+++ b/bracket-terminal/src/hal/framebuffer.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use glow::HasContext;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -14,14 +15,14 @@ pub struct Framebuffer {
 
 impl Framebuffer {
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn build_fbo(gl: &glow::Context, width: i32, height: i32) -> Framebuffer {
+    pub fn build_fbo(gl: &glow::Context, width: i32, height: i32) -> Result<Framebuffer> {
         let fbo;
         let buffer;
 
         unsafe {
-            fbo = gl.create_framebuffer().unwrap();
+            fbo = gl.create_framebuffer()?;
             gl.bind_framebuffer(glow::FRAMEBUFFER, Some(fbo));
-            buffer = gl.create_texture().unwrap();
+            buffer = gl.create_texture()?;
 
             gl.bind_texture(glow::TEXTURE_2D, Some(buffer));
             gl.tex_image_2d(
@@ -66,10 +67,11 @@ impl Framebuffer {
             gl.bind_framebuffer(glow::FRAMEBUFFER, None);
         }
 
-        Framebuffer {
+        let framebuffer = Framebuffer {
             fbo,
             texture: buffer,
-        }
+        };
+        Ok(framebuffer)
     }
 
     #[cfg(target_arch = "wasm32")]

--- a/bracket-terminal/src/hal/native/font.rs
+++ b/bracket-terminal/src/hal/native/font.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::prelude::{embedding, BTermPlatform};
 use glow::HasContext;
 use image::{ColorType, GenericImageView};
@@ -52,12 +53,12 @@ impl Font {
     }
 
     /// Load a font, and allocate it as an OpenGL resource. Returns the OpenGL binding number (which is also set in the structure).
-    pub fn setup_gl_texture(&mut self, platform: &BTermPlatform) -> u32 {
+    pub fn setup_gl_texture(&mut self, platform: &BTermPlatform) -> Result<u32> {
         let gl = &platform.platform.gl;
         let texture;
 
         unsafe {
-            texture = gl.create_texture().unwrap();
+            texture = gl.create_texture()?;
             gl.bind_texture(glow::TEXTURE_2D, Some(texture));
             gl.tex_parameter_i32(
                 glow::TEXTURE_2D,
@@ -110,7 +111,7 @@ impl Font {
 
         self.gl_id = Some(texture);
 
-        texture
+        Ok(texture)
     }
 
     /// Sets this font file as the active texture

--- a/bracket-terminal/src/hal/native/init.rs
+++ b/bracket-terminal/src/hal/native/init.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::prelude::{InitHints, BTerm, BTermPlatform};
 use glutin::{dpi::LogicalSize, event_loop::EventLoop, window::WindowBuilder, ContextBuilder};
 use crate::hal::native::{WrappedContext, PlatformGL, setup_quad, shader::Shader, shader_strings};
@@ -8,7 +9,7 @@ pub fn init_raw<S: ToString>(
     height_pixels: u32,
     window_title: S,
     platform_hints: InitHints,
-) -> BTerm {
+) -> Result<BTerm> {
 
     let el = EventLoop::new();
     let wb = WindowBuilder::new()
@@ -68,12 +69,12 @@ pub fn init_raw<S: ToString>(
         &gl,
         (width_pixels as f64 * initial_dpi_factor) as i32,
         (height_pixels as f64 * initial_dpi_factor) as i32,
-    );
+    )?;
 
     // Build a simple quad rendering vao
     let quad_vao = setup_quad(&gl);
 
-    BTerm {
+    let bterm = BTerm {
         backend: BTermPlatform {
             platform: PlatformGL {
                 gl,
@@ -104,5 +105,6 @@ pub fn init_raw<S: ToString>(
         quitting: false,
         post_scanlines: false,
         post_screenburn: false,
-    }
+    };
+    Ok(bterm)
 }

--- a/bracket-terminal/src/hal/native/init.rs
+++ b/bracket-terminal/src/hal/native/init.rs
@@ -24,15 +24,17 @@ pub fn init_raw<S: ToString>(
         .with_hardware_acceleration(Some(true))
         .with_vsync(platform_hints.vsync)
         .with_srgb(platform_hints.srgb)
-        .build_windowed(wb, &el)
-        .unwrap();
+        .build_windowed(wb, &el)?;
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
     if platform_hints.fullscreen {
-        let mh = el.available_monitors().nth(0).unwrap();
-        windowed_context
-            .window()
-            .set_fullscreen(Some(glutin::window::Fullscreen::Borderless(mh)));
+        if let Some(mh) = el.available_monitors().nth(0) {
+            windowed_context
+                .window()
+                .set_fullscreen(Some(glutin::window::Fullscreen::Borderless(mh)));
+        } else {
+            return Err("No available monitor found".into());
+        }
     }
 
     let gl = glow::Context::from_loader_function(|ptr| {

--- a/bracket-terminal/src/hal/native/mainloop.rs
+++ b/bracket-terminal/src/hal/native/mainloop.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::prelude::{Console, GameState, BTerm};
 use crate::hal::*;
 use glow::HasContext;
@@ -6,7 +7,7 @@ use std::time::Instant;
 
 const TICK_TYPE: ControlFlow = ControlFlow::Poll;
 
-fn on_resize(bterm: &mut BTerm, physical_size: glutin::dpi::PhysicalSize<u32>) {
+fn on_resize(bterm: &mut BTerm, physical_size: glutin::dpi::PhysicalSize<u32>) -> Result<()> {
     bterm.resize_pixels(physical_size.width as u32, physical_size.height as u32);
     unsafe {
         bterm.backend.platform.gl.viewport(
@@ -20,10 +21,11 @@ fn on_resize(bterm: &mut BTerm, physical_size: glutin::dpi::PhysicalSize<u32>) {
         &bterm.backend.platform.gl,
         physical_size.width as i32,
         physical_size.height as i32,
-    );
+    )?;
+    Ok(())
 }
 
-pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) {
+pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) -> Result<()> {
     let now = Instant::now();
     let mut prev_seconds = now.elapsed().as_secs();
     let mut prev_ms = now.elapsed().as_millis();
@@ -37,7 +39,7 @@ pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) {
     let el = unwrap.el;
     let wc = unwrap.wc;
 
-    on_resize(&mut bterm, wc.window().inner_size()); // Additional resize to handle some X11 cases
+    on_resize(&mut bterm, wc.window().inner_size())?; // Additional resize to handle some X11 cases
 
     el.run(move |event, _, control_flow| {
         *control_flow = TICK_TYPE;
@@ -77,7 +79,7 @@ pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) {
             Event::LoopDestroyed => (),
             Event::WindowEvent { ref event, .. } => match event {
                 WindowEvent::Resized(physical_size) => {
-                    on_resize(&mut bterm, *physical_size);
+                    on_resize(&mut bterm, *physical_size).unwrap();
                 }
                 WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
 
@@ -90,7 +92,7 @@ pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) {
                 }
 
                 WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
-                    on_resize(&mut bterm, **new_inner_size);
+                    on_resize(&mut bterm, **new_inner_size).unwrap();
                 }
 
                 WindowEvent::KeyboardInput {

--- a/bracket-terminal/src/hal/native/simple_console_backing.rs
+++ b/bracket-terminal/src/hal/native/simple_console_backing.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::prelude::Tile;
 use crate::hal::{font::Font, shader::Shader};
 use bracket_color::prelude::RGB;
@@ -263,7 +264,7 @@ impl SimpleConsoleBackend {
         platform: &super::super::BTermPlatform,
         width: u32,
         height: u32,
-    ) {
+    ) -> Result<()> {
         let gl = &platform.platform.gl;
         unsafe {
             // bind Texture
@@ -281,5 +282,6 @@ impl SimpleConsoleBackend {
                 0,
             );
         }
+        Ok(())
     }
 }

--- a/bracket-terminal/src/hal/native/sparse_console_backing.rs
+++ b/bracket-terminal/src/hal/native/sparse_console_backing.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use bracket_color::prelude::RGB;
 use crate::hal::{font::Font, shader::Shader};
 use crate::sparse_console::SparseTile;
@@ -211,7 +212,7 @@ impl SparseConsoleBackend {
         shader: &Shader,
         platform: &super::super::BTermPlatform,
         tiles: &[SparseTile],
-    ) {
+    ) -> Result<()> {
         let gl = &platform.platform.gl;
         unsafe {
             // bind Texture
@@ -229,5 +230,6 @@ impl SparseConsoleBackend {
                 0,
             );
         }
+        Ok(())
     }
 }

--- a/bracket-terminal/src/initializer.rs
+++ b/bracket-terminal/src/initializer.rs
@@ -86,12 +86,12 @@ impl BTermBuilder {
     }
 
     /// Provides an 8x8 terminal font simple console, with the specified dimensions as your starting point.
-    pub fn simple<T>(width: T, height: T) -> Self
+    pub fn simple<T>(width: T, height: T) -> Result<Self>
     where
         T: TryInto<u32>,
     {
-        let w: u32 = width.try_into().ok().expect("Must be convertible to a u32");
-        let h: u32 = height.try_into().ok().expect("Must be convertible to a u32");
+        let w: u32 = width.try_into().or(Err("Must be convertible to a u32"))?;
+        let h: u32 = height.try_into().or(Err("Must be convertible to a u32"))?;
         let mut cb = BTermBuilder {
             width: w,
             height: h,
@@ -112,7 +112,7 @@ impl BTermBuilder {
             height: h,
             font: "terminal8x8.png".to_string(),
         });
-        cb
+        Ok(cb)
     }
 
     /// Provides an 80x50 terminal, in the VGA font as your starting point.
@@ -304,7 +304,7 @@ impl BTermBuilder {
         for font in &self.fonts {
             let font_path = format!("{}/{}", self.resource_path, font.path);
             let font_id = context.register_font(Font::load(font_path.clone(), font.dimensions));
-            font_map.insert(font_path, font_id);
+            font_map.insert(font_path, font_id?);
         }
 
         for console in &self.consoles {

--- a/bracket-terminal/src/initializer.rs
+++ b/bracket-terminal/src/initializer.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use crate::prelude::{init_raw, BTerm, InitHints, SimpleConsole, SparseConsole, font::Font};
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -291,13 +292,13 @@ impl BTermBuilder {
     }
 
     /// Combine all of the builder parameters, and return an BTerm context ready to go.
-    pub fn build(self) -> BTerm {
+    pub fn build(self) -> Result<BTerm> {
         let mut context = init_raw(
             self.width * self.tile_width,
             self.height * self.tile_height,
             self.title.unwrap_or("BTerm Window".to_string()),
             self.platform_hints,
-        );
+        )?;
 
         let mut font_map: HashMap<String, usize> = HashMap::new();
         for font in &self.fonts {
@@ -347,6 +348,6 @@ impl BTermBuilder {
             }
         }
 
-        context
+        Ok(context)
     }
 }

--- a/bracket-terminal/src/lib.rs
+++ b/bracket-terminal/src/lib.rs
@@ -15,7 +15,7 @@ mod bterm;
 pub mod embedding;
 mod gamestate;
 
-pub(crate) type Error = String;
+pub(crate) type Error = Box<dyn std::error::Error>;
 pub(crate) type Result<T> = core::result::Result<T, Error>;
 
 pub mod prelude {

--- a/bracket-terminal/src/lib.rs
+++ b/bracket-terminal/src/lib.rs
@@ -15,6 +15,9 @@ mod bterm;
 pub mod embedding;
 mod gamestate;
 
+pub(crate) type Error = String;
+pub(crate) type Result<T> = core::result::Result<T, Error>;
+
 pub mod prelude {
 
     pub use crate::hal::{Shader, font, InitHints, init_raw, BTermPlatform, SimpleConsoleBackend, SparseConsoleBackend};

--- a/bracket-terminal/src/simple_console.rs
+++ b/bracket-terminal/src/simple_console.rs
@@ -84,7 +84,7 @@ impl Console for SimpleConsole {
     /// Sends the console to OpenGL.
     fn gl_draw(&mut self, font: &Font, shader: &Shader, platform: &BTermPlatform) {
         self.backend
-            .gl_draw(font, shader, platform, self.width, self.height);
+            .gl_draw(font, shader, platform, self.width, self.height).unwrap();
         self.is_dirty = false;
     }
 

--- a/bracket-terminal/src/sparse_console.rs
+++ b/bracket-terminal/src/sparse_console.rs
@@ -82,7 +82,7 @@ impl Console for SparseConsole {
 
     /// Draws the console to OpenGL.
     fn gl_draw(&mut self, font: &Font, shader: &Shader, platform: &BTermPlatform) {
-        self.backend.gl_draw(font, shader, platform, &self.tiles);
+        self.backend.gl_draw(font, shader, platform, &self.tiles).unwrap();
         self.is_dirty = false;
     }
 


### PR DESCRIPTION
Made a PR to bracket-terminal (original commit for reference: spenserblack/bracket-terminal@8d2d8636ed47078cbb642400b011b8805d4067cc) last week, this PR follows the same basic intent (though vastly different implementation).

This PR follows the same idea of removing panicking code and instead providing the user with Error types for them to handle, but I may have gone overboard :laughing:. If I did, I'm happy to rebase away some changes/make a new PR.

I've checked that the examples run, and that it compiles with
- default features
- crossterm
- curses
- amethyst_engine_vulkan

Haven't tested with amethyst_engine_metal, or with the wasm32 target yet.

If this PR is worth merging, it might be a good idea to have a bracket-error crate, to standardize an error type across these crates.