### PR TITLE
Fix threaded and unthreaded dijkstra map

### DIFF
--- a/bracket-pathfinding/Cargo.toml
+++ b/bracket-pathfinding/Cargo.toml
@@ -21,6 +21,7 @@ threaded = ["rayon"]
 bracket-geometry = { path = "../bracket-geometry" }
 bracket-algorithm-traits = { path = "../bracket-algorithm-traits" }
 rayon = { version = "1.3.0", optional = true }
+smallvec = "1.2.0"
 
 [dev-dependencies]
 crossterm = "0.16.0"

--- a/bracket-pathfinding/examples/dijkstra/main.rs
+++ b/bracket-pathfinding/examples/dijkstra/main.rs
@@ -23,7 +23,14 @@ fn main() {
                 '#' => RGB::named(YELLOW),
                 _ => {
                     if flow_map.map[idx] < std::f32::MAX {
-                        RGB::from_u8(0, 255 - (flow_map.map[idx]) as u8, 0)
+                        RGB::from_u8(
+                            0,
+                            255 - {
+                                let n = flow_map.map[idx] * 6.0;
+                                if n > 255.0 { 255.0 } else { n }
+                            } as u8,
+                            0,
+                        )
                     } else {
                         RGB::named(CHOCOLATE)
                     }

--- a/bracket-pathfinding/src/dijkstra.rs
+++ b/bracket-pathfinding/src/dijkstra.rs
@@ -113,8 +113,7 @@ impl DijkstraMap {
     /// depth is further than the current depth.
     /// WARNING: Will give incorrect results when used with non-uniform exit costs. Much slower
     /// algorithm required to support that.
-    /// If you provide more starting points than you have CPUs, automatically branches to a parallel
-    /// version.
+    /// Automatically branches to a parallel version if you provide more than 4 starting points
     pub fn build(dm: &mut DijkstraMap, starts: &[usize], map: &dyn BaseMap) {
         let threaded = DijkstraMap::build_helper(dm, starts, map);
         if threaded == RunThreaded::True { return; }

--- a/bracket-pathfinding/src/lib.rs
+++ b/bracket-pathfinding/src/lib.rs
@@ -8,4 +8,7 @@ pub mod prelude {
     pub use crate::fieldofview::*;
     pub use bracket_algorithm_traits::prelude::*;
     pub use bracket_geometry::prelude::*;
+
+    /// Since we use `SmallVec`, it's only polite to export it so you don't have to have multiple copies.
+    pub use smallvec::{SmallVec, smallvec};
 }


### PR DESCRIPTION
See https://github.com/thebracket/bracket-lib/issues/103

# Changes
* Fix dijkstra map building. It was building incorrect maps before.
* Removed all usages of unsafe, as the speedy clearing of buffers isn't necessary with the new algorithm.
* Change the dijkstra example code to better show the flow
* Make the threaded version **not** also run the unthreaded version at the same time
* Arbitrarily run threaded version if there are 4 or more starts. This might be a bad idea, see below.

# Notes

The algorithm used **probably** ensures there are no re-visits of nodes when run single threaded. Should just be BFS with a single start, and lockstepped BFSes with multiple starts. Most of the time in the build functions is spent in calls to `get_available_exits`. The single threaded version should call this at most once per **visited** node, while the multi-threaded one will always call it once for **every** node.

For me, the multi threaded program spends something like 30% of its time in rayon functions, ~2% in the dijkstra build function. Single threaded spends ~4% of its time in the dijkstra build function in a similar test. I think one would need to get up to pretty huge map sizes for the multi threaded version to be preferable. Haven't got the time to do tests for that yet.

It's probably possible to make the threaded version only call `get_available_exits` on demand, since it seems like it should be a read-only operation. I'll leave that work to someone with the need for it.