### PR TITLE
Make error type compatible with anyhow lib

### DIFF
--- a/bracket-terminal/src/lib.rs
+++ b/bracket-terminal/src/lib.rs
@@ -9,7 +9,7 @@ mod initializer;
 mod input;
 pub mod rex;
 
-pub(crate) type Error = Box<dyn std::error::Error>;
+pub(crate) type Error = Box<dyn std::error::Error + 'static>;
 pub(crate) type Result<T> = core::result::Result<T, Error>;
 pub(crate) use input::clear_input_state;
 pub type FontCharType = u16;

--- a/bracket-terminal/src/lib.rs
+++ b/bracket-terminal/src/lib.rs
@@ -9,7 +9,7 @@ mod initializer;
 mod input;
 pub mod rex;
 
-pub(crate) type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
 pub(crate) type Result<T> = core::result::Result<T, Error>;
 pub(crate) use input::clear_input_state;
 pub type FontCharType = u16;

--- a/bracket-terminal/src/lib.rs
+++ b/bracket-terminal/src/lib.rs
@@ -9,7 +9,7 @@ mod initializer;
 mod input;
 pub mod rex;
 
-pub(crate) type Error = Box<dyn std::error::Error + 'static>;
+pub(crate) type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub(crate) type Result<T> = core::result::Result<T, Error>;
 pub(crate) use input::clear_input_state;
 pub type FontCharType = u16;


### PR DESCRIPTION
Adding additional constraints for Error type would allow to easily convert from `bracket-lib::Error` to `anyhow::Error` like so:

```rust
    let context = BTermBuilder::simple80x50()
        .with_title("Title")
        .build()
        .map_err(|e| anyhow!(e))?;
```