### PR TITLE
Accept new ultraviolet patches

### DIFF
--- a/bracket-geometry/Cargo.toml
+++ b/bracket-geometry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bracket-geometry"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Herbert Wolverson <herberticus@gmail.com>"]
 edition = "2018"
 publish = true
@@ -13,7 +13,7 @@ categories = ["game-engines", "graphics"]
 license = "MIT"
 
 [dependencies]
-ultraviolet = "0.4.5"
+ultraviolet = "~0.4.6"
 serde = { version = "1.0.106", features = ["derive"], optional = true }
 specs = { version = "0.16.1", optional = true }
 


### PR DESCRIPTION
Requires ultraviolet 0.4.6, which relies on wide.
wide broke its API to fix incorrect math, breaking ultraviolet (and thus bracket) builds.
~ sets a minimum ver but allows accepting patch progress without new releases.
Closes #119.

alternative solutions:
fork ultraviolet and depend on your fork, with a hard-pinned wide dep instead of soft-pinned like this, but now you have to update manually to accept patches. Seems like effort.