### PR TITLE
Prep 0.8.1 to allow self-patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bracket-lib"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Herbert Wolverson <herberticus@gmail.com>"]
 edition = "2018"
 publish = true
@@ -37,7 +37,7 @@ amethyst_engine_metal = [ "bracket-terminal/amethyst_engine_metal" ]
 [dependencies]
 bracket-algorithm-traits = { version = "0.8.0" }
 bracket-color = { version = "0.8.0", features = [ "rex", "palette" ] }
-bracket-geometry = { version = "0.8.0" }
+bracket-geometry = { version = "~0.8.1" }
 bracket-noise = { version = "0.8.0" }
 bracket-pathfinding = { version = "0.8.0" }
 bracket-random = { version = "0.8.0", features = [ "parsing" ] }

--- a/rltk/Cargo.toml
+++ b/rltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rltk"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Herbert Wolverson <herberticus@gmail.com>"]
 edition = "2018"
 publish = true
@@ -24,7 +24,7 @@ amethyst_engine_vulkan = [ "bracket-lib/amethyst_engine_vulkan" ]
 amethyst_engine_metal = [ "bracket-lib/amethyst_engine_metal" ]
 
 [dependencies]
-bracket-lib = { version = "0.8.0", default-features = false }
+bracket-lib = { version = "~0.8.1", default-features = false }
 
 [dev-dependencies]
 


### PR DESCRIPTION
This makes more sense if you've read #120 first.
I would not normally offer such a PR because while the dep on ultraviolet needs to be fixed, this feels more like dictating a release strategy. So I do so as a separate PR because I realize you might not care for such a recommendation, but I do so anyways in spite of the vague feeling it is overly forward because I realize that your extreme busy-ness might mean that you appreciate such a recommendation and everything being set up so you just have to hit the button. So, please feel free to accept or reject as you please.

This implements all the changes to allow rltk to passively (without a release) accept the patches from bracket-lib which would accept the patches from bracket-geometry which would accept the patches from ultraviolet which _does_ accept the patches from wide.