### PR TITLE
remove bad unsafe usage

### DIFF
--- a/bracket-random/src/iterators.rs
+++ b/bracket-random/src/iterators.rs
@@ -2,13 +2,13 @@ use crate::prelude::RandomNumberGenerator;
 use core::iter::Iterator;
 use std::convert::TryInto;
 
-pub struct DiceIterator {
+pub struct DiceIterator<'a> {
     die_type: i32,
-    rng: *mut RandomNumberGenerator,
+    rng: &'a mut RandomNumberGenerator,
 }
 
-impl DiceIterator {
-    pub fn new<T>(die_type: T, rng: &mut RandomNumberGenerator) -> Self
+impl<'a> DiceIterator<'a> {
+    pub fn new<T>(die_type: T, rng: &'a mut RandomNumberGenerator) -> Self
     where
         T: TryInto<i32>,
     {
@@ -17,10 +17,10 @@ impl DiceIterator {
     }
 }
 
-impl Iterator for DiceIterator {
+impl<'a> Iterator for DiceIterator<'a> {
     type Item = i32;
 
     fn next(&mut self) -> Option<i32> {
-        unsafe { Some(self.rng.as_mut().unwrap().roll_dice(1, self.die_type)) }
+        Some(self.rng.roll_dice(1, self.die_type))
     }
 }


### PR DESCRIPTION
Prior to this change, the following code is accepted by the Rust compiler:
```rust
use bracket_random::prelude::*;

fn make_bad() -> DiceIterator {
    DiceIterator::new(10, &mut RandomNumberGenerator::new())
}

fn main() {
    let dice = make_bad();
    let res = dice.zip(0..100).collect::<Vec<_>>();
    println!("Results: {:?}", res)
}
```
It clearly exhibits undefined behavior, dereferencing a pointer to a `RandomNumberGenerator` that doesn't live long enough.

In testing that snippet, I did the following:
I built and ran it in debug mode, which printed the vector of results that might be expected.

I built and ran it in release mode, which segfaulted.
`Segmentation fault (core dumped)`

I ran it with Miri, which spat out a long error message. This is the important part:
```
Undefined Behavior: pointer to alloc1420 was dereferenced after this allocation got freed
```

After this PR, such behavior is impossible to invoke.