### PR TITLE
Consider zero point as in bounds for algorithms.

### DIFF
--- a/bracket-algorithm-traits/src/algorithm2d.rs
+++ b/bracket-algorithm-traits/src/algorithm2d.rs
@@ -47,7 +47,7 @@ pub trait Algorithm2D: BaseMap {
     // the time, that's what you want.
     fn in_bounds(&self, pos: Point) -> bool {
         let bounds = self.dimensions();
-        pos.x > 0 && pos.x < bounds.x && pos.y > 0 && pos.y < bounds.y
+        pos.x >= 0 && pos.x < bounds.x && pos.y >= 0 && pos.y < bounds.y
     }
 }
 
@@ -79,6 +79,7 @@ mod tests {
         }
 
         let map = TestMap {};
+        assert!(map.in_bounds(Point::new(0, 0)));
         assert!(map.in_bounds(Point::new(1, 1)));
         assert!(!map.in_bounds(Point::new(3, 3)));
     }

--- a/bracket-algorithm-traits/src/algorithm3d.rs
+++ b/bracket-algorithm-traits/src/algorithm3d.rs
@@ -52,11 +52,11 @@ pub trait Algorithm3D: BaseMap {
     // the time, that's what you want.
     fn in_bounds(&self, pos: Point3) -> bool {
         let bounds = self.dimensions();
-        pos.x > 0
+        pos.x >= 0
             && pos.x < bounds.x
-            && pos.y > 0
+            && pos.y >= 0
             && pos.y < bounds.y
-            && pos.z > 0
+            && pos.z >= 0
             && pos.z < bounds.z
     }
 }
@@ -89,6 +89,7 @@ mod tests {
         }
 
         let map = TestMap {};
+        assert!(map.in_bounds(Point3::new(0, 0, 0)));
         assert!(map.in_bounds(Point3::new(1, 1, 1)));
         assert!(!map.in_bounds(Point3::new(3, 3, 3)));
     }

--- a/bracket-pathfinding/src/fieldofview.rs
+++ b/bracket-pathfinding/src/fieldofview.rs
@@ -110,9 +110,9 @@ mod tests {
         let visible = field_of_view(Point::new(2, 2), 8, &map);
 
         for t in visible.iter() {
-            assert!(t.x > 0);
+            assert!(t.x >= 0);
             assert!(t.x < TESTMAP_W as i32 - 1);
-            assert!(t.y > 0);
+            assert!(t.y >= 0);
             assert!(t.y < TESTMAP_H as i32 - 1);
         }
     }


### PR DESCRIPTION
Fixes #116: when a point with a zero-coordinate was considered as not in bounds for map algorithms. The bug is the root cause of the problem that zero-coordinate points are always not visible.

![image](https://user-images.githubusercontent.com/3457402/80926505-6ced5b80-8da0-11ea-8b94-34027c452cfe.png)


