### PR TITLE
Fix modifier keys

### DIFF
--- a/bracket-terminal/src/input/input_handler.rs
+++ b/bracket-terminal/src/input/input_handler.rs
@@ -8,9 +8,6 @@ use std::collections::{HashSet, VecDeque};
 pub(crate) fn clear_input_state(term: &mut BTerm) {
     term.key = None;
     term.left_click = false;
-    term.shift = false;
-    term.control = false;
-    term.alt = false;
     term.web_button = None;
 }
 


### PR DESCRIPTION
Fixes #66  
The reason why modifier keys don't work is their state is reset in clear_input_state() called on Event::NewEvents every tick.  
This PR removes the lines that reset the states.  
![image](https://user-images.githubusercontent.com/29710855/81988521-95196c00-9676-11ea-9789-7952f3c26421.png)