### PR TITLE
moved all crates into separate modules in bracket-lib/lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+//! bracket-lib is a wrapper of the bracket- set of crates designed initally
+//! for roguelike development (as RLTK) and later transitioned into a general
+//! use crate.
+
+/// prelude
 pub mod prelude {
     pub use bracket_algorithm_traits::prelude::*;
     pub use bracket_color::prelude::*;
@@ -7,4 +12,43 @@ pub mod prelude {
     pub use bracket_random::prelude::*;
     pub use bracket_terminal::prelude::*;
     pub use bracket_terminal::{add_wasm_support, embedded_resource, link_resource};
+}
+
+/// bracket-algorithm-traits provides traits for use in the bracket-pathfinding
+/// and bracket-geometry
+pub mod algorithm_traits {
+    pub use bracket_algorithm_traits::prelude::*;
+}
+
+/// bracket-color provides a color system for use in the bracket-terminal
+pub mod color {
+    pub use bracket_color::prelude::*;
+}
+/// bracket-geometry provides some geometric primitives (Point, Point3D, Rect),
+/// support functions and distance calculations. It also includes Bresenham's
+/// line algorithm, a vector line algorithm, and Bresenham's Circle algorithm.
+pub mod geometry {
+    pub use bracket_geometry::prelude::*;
+}
+
+/// bracket-noise covers all the commonly used types of noise,
+pub mod noise {
+    pub use bracket_noise::prelude::*;
+}
+/// bracket-pathfinding (in conjunction with bracket-algorithm-traits) provides
+/// pathfinding functionality. A-Star (A*) and Dijkstra are supported. It also
+// provides field of view (FOV) functionality.
+pub mod pathfinding {
+    pub use bracket_pathfinding::prelude::*;
+}
+
+/// bracket-random provides a dice-oriented random number generation
+pub mod random {
+    pub use bracket_random::prelude::*;
+}
+
+/// bracket-terminal provides a virtual ASCII/Codepage-437 terminal (with
+/// optional tile graphic support and layers), and a game loop
+pub mod terminal {
+    pub use bracket_terminal::prelude::*;
 }


### PR DESCRIPTION
The crate felt really messy on the documentation side of things with everything being namespaced in prelude only (especially with the color const's) so I just added some modules in the root to split things up a bit and make it more readable and more inline with most rust crates setup.