### PR TITLE
Makes astar benchmark run.

### DIFF
--- a/bracket-pathfinding/benches/astar_benchmark.rs
+++ b/bracket-pathfinding/benches/astar_benchmark.rs
@@ -63,6 +63,11 @@ impl Map {
 
     fn valid_exit(&self, loc: Point, delta: Point) -> Option<usize> {
         let destination = loc + delta;
+
+        if destination.x < 0 || destination.y < 0 {
+            return None
+        }
+
         let idx = self.point2d_to_index(destination);
         if self.in_bounds(destination) && self.tiles[idx] == '.' {
             Some(idx)


### PR DESCRIPTION
valid_exit() in the benchmark will receive negative x and y deltas
from get_available_exist() which when the point they are examining a loc
which is x=0 or y=0 would create a negative search position.  This in
turn would panic in algorithm2d when trying to coerce them into usize.