### PR TITLE
Remove sprites.is_empty() Check

### DIFF
--- a/bracket-terminal/src/hal/gl_common/backing/sprite_console_backing.rs
+++ b/bracket-terminal/src/hal/gl_common/backing/sprite_console_backing.rs
@@ -59,10 +59,6 @@ impl SpriteConsoleBackend {
         sprites: &[RenderSprite],
         sprite_sheet: &SpriteSheet,
     ) {
-        if sprites.is_empty() {
-            return;
-        }
-
         let scale_x = 1.0 / (width as f32 * 0.5);
         let scale_y = 1.0 / (height as f32 * 0.5);
 


### PR DESCRIPTION
This should fix the issue with `cls()` not actually clearing the console if nothing is then rendered on it.

This applies a fix similar to the one found in #117, but for the sprite console instead of the sparse console.