### PR TITLE
stop forcing WINIT_UNIX_BACKEND env var to fix wayland

### DIFF
--- a/bracket-terminal/src/hal/native/init.rs
+++ b/bracket-terminal/src/hal/native/init.rs
@@ -11,9 +11,6 @@ pub fn init_raw<S: ToString>(
     window_title: S,
     platform_hints: InitHints,
 ) -> Result<BTerm> {
-    // Force Wayland to use X11, which actually works.
-    std::env::set_var("WINIT_UNIX_BACKEND", "x11");
-
     let el = EventLoop::new();
     let wb = WindowBuilder::new()
         .with_title(window_title.to_string())


### PR DESCRIPTION
Removes `std::env::set_var("WINIT_UNIX_BACKEND", "x11")` which breaks support on pure Wayland environments that have no x11 capabilities.

Fixes #161 