### PR TITLE
Add xp_to_draw_batch, to the tune of xp_to_console

### DIFF
--- a/bracket-terminal/src/rex.rs
+++ b/bracket-terminal/src/rex.rs
@@ -191,6 +191,24 @@ pub fn xp_to_console(
     }
 }
 
+/// Applies an XpFile to a given draw batch, with 0,0 offset by offset_x and offset-y.
+pub fn xp_to_draw_batch(xp: &XpFile, draw_batch: &mut DrawBatch, offset_x: i32, offset_y: i32) {
+    for layer in &xp.layers {
+        for y in 0..layer.height {
+            for x in 0..layer.width {
+                let cell = layer.get(x, y).unwrap();
+                if !cell.bg.is_transparent() {
+                    draw_batch.set(
+                        Point::new(x as i32 + offset_x, y as i32 + offset_y),
+                        ColorPair::new(RGB::from_xp(cell.fg), RGB::from_xp(cell.bg)),
+                        cell.ch as FontCharType,
+                    );
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Possibly there's a way to DRY these functions with some common trait, but at a glance I couldn't find one.