### PR TITLE
Upgrade smallvec

### DIFF
--- a/bracket-algorithm-traits/Cargo.toml
+++ b/bracket-algorithm-traits/Cargo.toml
@@ -16,4 +16,4 @@ license = "MIT"
 
 [dependencies]
 bracket-geometry = { path = "../bracket-geometry", version = "~0.8.1" }
-smallvec = "~1.4.0"
+smallvec = "~1.6.0"

--- a/bracket-pathfinding/Cargo.toml
+++ b/bracket-pathfinding/Cargo.toml
@@ -21,7 +21,7 @@ threaded = ["rayon"]
 bracket-geometry = { path = "../bracket-geometry", version = "~0.8.1" }
 bracket-algorithm-traits = { path = "../bracket-algorithm-traits", version = "~0.8.1" }
 rayon = { version = "1.3.0", optional = true }
-smallvec = "~1.4.0"
+smallvec = "~1.6.0"
 
 [dev-dependencies]
 crossterm = "~0.17.4"


### PR DESCRIPTION
Because Legion requires 1.6, which means recent `bracket-lib` cannot live in the same project as Legion.